### PR TITLE
Ads API: v16 -> v17

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,8 +9,8 @@ Download the x86_64 static binary from [releases](https://github.com/maiha/faceb
 You can send an arbitrary GET request to the Facebook Marketing API.
 
 ```console
-$ facebook api get '/v16.0/me' -a <ACCESS_TOKEN>
-$ facebook api get '/v16.0/me/adaccounts -d fields=account_id,name' -a <ACCESS_TOKEN>
+$ facebook api get '/v17.0/me' -a <ACCESS_TOKEN>
+$ facebook api get '/v17.0/me/adaccounts -d fields=account_id,name' -a <ACCESS_TOKEN>
 ```
 
 Access tokens and other information can be put together in a configuration file.

--- a/spec/cli/batch_spec.cr
+++ b/spec/cli/batch_spec.cr
@@ -1,7 +1,7 @@
 require "./spec_helper"
 
 private def current_url
-  "https://graph.facebook.com/v16.0/act_123/campaigns?access_token=xxx&fields=id%2Cname&limit=100&after=abc"
+  "https://graph.facebook.com/v17.0/act_123/campaigns?access_token=xxx&fields=id%2Cname&limit=100&after=abc"
 end
 
 private def reduce_data(*args)
@@ -15,7 +15,7 @@ end
 describe Cmds::BatchCmd::ReduceData do
   describe ".update_limit(url, limit)" do
     it "replace limit parameter" do
-      Cmds::BatchCmd::ReduceData.update_limit(current_url, 10).should eq "https://graph.facebook.com/v16.0/act_123/campaigns?access_token=xxx&fields=id%2Cname&limit=10&after=abc"
+      Cmds::BatchCmd::ReduceData.update_limit(current_url, 10).should eq "https://graph.facebook.com/v17.0/act_123/campaigns?access_token=xxx&fields=id%2Cname&limit=10&after=abc"
     end
 
     it "do nothing when limit is nil" do
@@ -35,11 +35,11 @@ describe Cmds::BatchCmd::ReduceData do
 
   describe ".reduce_data(current_url, min_limit)" do
     it "builds reduced_url by setting limit to limit/2" do
-      reduce_data(current_url, 10).should eq "https://graph.facebook.com/v16.0/act_123/campaigns?access_token=xxx&fields=id%2Cname&limit=50&after=abc"
+      reduce_data(current_url, 10).should eq "https://graph.facebook.com/v17.0/act_123/campaigns?access_token=xxx&fields=id%2Cname&limit=50&after=abc"
     end
 
     it "respects min_limit" do
-      reduce_data(current_url, 99).should eq "https://graph.facebook.com/v16.0/act_123/campaigns?access_token=xxx&fields=id%2Cname&limit=99&after=abc"
+      reduce_data(current_url, 99).should eq "https://graph.facebook.com/v17.0/act_123/campaigns?access_token=xxx&fields=id%2Cname&limit=99&after=abc"
     end
 
     it "raises when it has already reached the min_limit" do

--- a/spec/facebook/client_spec.cr
+++ b/spec/facebook/client_spec.cr
@@ -8,8 +8,8 @@ describe Facebook::Client do
     end
 
     it "respects api" do
-      client = Facebook::Client.new(api: "/v16.0/me")
-      client.request.to_s.should eq("https://graph.facebook.com/v16.0/me")
+      client = Facebook::Client.new(api: "/v17.0/me")
+      client.request.to_s.should eq("https://graph.facebook.com/v17.0/me")
 
       client = Facebook::Client.new
       client.api = Facebook::Api::Get.new("/me", data: {"limit" => "2"})

--- a/src/cli/cmds/api.cr
+++ b/src/cli/cmds/api.cr
@@ -19,14 +19,14 @@ Cmds.command "api" do
     show(res)
   end
 
-  desc "adaccounts", "# get '/v16.0/me/adaccounts'"
+  desc "adaccounts", "# get '/v17.0/me/adaccounts'"
   task adaccounts do
     limit = config.limit? || 10
-    res = client.get("/v16.0/me/adaccounts -d limit=#{limit}")
+    res = client.get("/v17.0/me/adaccounts -d limit=#{limit}")
     show(res)
   end
 
-  desc "get '/v16.0/me/adaccounts -d fields=name,age -d limit=300'", "# get 'XXX' as is"
+  desc "get '/v17.0/me/adaccounts -d fields=name,age -d limit=300'", "# get 'XXX' as is"
   task get, "XXX" do
     if limit = config.limit?
       res = client.get(arg1, {"limit" => limit.to_s})

--- a/src/cli/facebook/config.cr
+++ b/src/cli/facebook/config.cr
@@ -239,25 +239,25 @@ colorize = true
 
 [ad_account]
 # funding_source raises "Permission Denied" see #2
-cmd = "/v16.0/me/adaccounts -d limit=100 -d fields=account_id,name,age,amount_spent,balance,business_city,business_country_code,business_name,business_state,business_street,business_street2,business_zip,can_create_brand_lift_study,created_time,currency,disable_reason,end_advertiser,end_advertiser_name,fb_entity,has_migrated_permissions,io_number,is_attribution_spec_system_default,is_direct_deals_enabled,is_in_3ds_authorization_enabled_market,is_in_middle_of_local_entity_migration,is_notifications_enabled,is_personal,is_prepay_account,is_tax_id_required,line_numbers,media_agency,min_campaign_group_spend_cap,min_daily_budget,offsite_pixels_tos_accepted,partner,spend_cap,tax_id,tax_id_status,tax_id_type,timezone_id,timezone_name,timezone_offset_hours_utc"
+cmd = "/v17.0/me/adaccounts -d limit=100 -d fields=account_id,name,age,amount_spent,balance,business_city,business_country_code,business_name,business_state,business_street,business_street2,business_zip,can_create_brand_lift_study,created_time,currency,disable_reason,end_advertiser,end_advertiser_name,fb_entity,has_migrated_permissions,io_number,is_attribution_spec_system_default,is_direct_deals_enabled,is_in_3ds_authorization_enabled_market,is_in_middle_of_local_entity_migration,is_notifications_enabled,is_personal,is_prepay_account,is_tax_id_required,line_numbers,media_agency,min_campaign_group_spend_cap,min_daily_budget,offsite_pixels_tos_accepted,partner,spend_cap,tax_id,tax_id_status,tax_id_type,timezone_id,timezone_name,timezone_offset_hours_utc"
 skip_400 = false
 
 [ad_set]
-cmd = "/v16.0/{act_id}/adsets -d limit=100 -d fields=id,account_id,asset_feed_id,bid_amount,bid_strategy,budget_remaining,campaign_id,created_time,creative_sequence,daily_budget,daily_min_spend_target,daily_spend_cap,destination_type,effective_status,end_time,instagram_actor_id,is_dynamic_creative,lifetime_budget,lifetime_imps,lifetime_min_spend_target,lifetime_spend_cap,name,optimization_goal,optimization_sub_event,pacing_type,recurring_budget_semantics,review_feedback,rf_prediction_id,source_adset_id,start_time,status,targeting,time_based_ad_rotation_id_blocks,time_based_ad_rotation_intervals,updated_time,use_new_app_click,date_format,execution_options,rb_prediction_id,time_start,time_stop"
+cmd = "/v17.0/{act_id}/adsets -d limit=100 -d fields=id,account_id,asset_feed_id,bid_amount,bid_strategy,budget_remaining,campaign_id,created_time,creative_sequence,daily_budget,daily_min_spend_target,daily_spend_cap,destination_type,effective_status,end_time,instagram_actor_id,is_dynamic_creative,lifetime_budget,lifetime_imps,lifetime_min_spend_target,lifetime_spend_cap,name,optimization_goal,optimization_sub_event,pacing_type,recurring_budget_semantics,review_feedback,rf_prediction_id,source_adset_id,start_time,status,targeting,time_based_ad_rotation_id_blocks,time_based_ad_rotation_intervals,updated_time,use_new_app_click,date_format,execution_options,rb_prediction_id,time_start,time_stop"
 
 [campaign]
-cmd = "/v16.0/{act_id}/campaigns -d fields=id,account_id,bid_strategy,boosted_object_id,budget_rebalance_flag,budget_remaining,buying_type,can_create_brand_lift_study,can_use_spend_cap,configured_status,created_time,daily_budget,effective_status,last_budget_toggling_time,lifetime_budget,name,objective,pacing_type,source_campaign_id,spend_cap,start_time,status,stop_time,topline_id,updated_time,execution_options"
+cmd = "/v17.0/{act_id}/campaigns -d fields=id,account_id,bid_strategy,boosted_object_id,budget_rebalance_flag,budget_remaining,buying_type,can_create_brand_lift_study,can_use_spend_cap,configured_status,created_time,daily_budget,effective_status,last_budget_toggling_time,lifetime_budget,name,objective,pacing_type,source_campaign_id,spend_cap,start_time,status,stop_time,topline_id,updated_time,execution_options"
 
 [ad]
 # preview_shareable_link: raises "Unsupported get request." for some ads
-cmd = "/v16.0/{act_id}/ads -d limit=80 -d fields=id,account_id,adset_id,bid_amount,bid_type,campaign_id,configured_status,created_time,demolink_hash,display_sequence,effective_status,engagement_audience,is_autobid,last_updated_by_app_id,name,priority,source_ad_id,status,targeting,updated_time,audience_id,date_format,draft_adgroup_id,execution_options,include_demolink_hashes"
+cmd = "/v17.0/{act_id}/ads -d limit=80 -d fields=id,account_id,adset_id,bid_amount,bid_type,campaign_id,configured_status,created_time,demolink_hash,display_sequence,effective_status,engagement_audience,is_autobid,last_updated_by_app_id,name,priority,source_ad_id,status,targeting,updated_time,audience_id,date_format,draft_adgroup_id,execution_options,include_demolink_hashes"
 
 [ad_image]
-cmd = "/v16.0/{act_id}/adimages -d limit=300 -d fields=id,name,width,height,url,account_id,permalink_url,original_width,original_height,status,created_time,updated_time"
+cmd = "/v17.0/{act_id}/adimages -d limit=300 -d fields=id,name,width,height,url,account_id,permalink_url,original_width,original_height,status,created_time,updated_time"
 
 [ad_rule]
-cmd = "/v16.0/{act_id}/adrules_library -d limit=300 -d fields=id,account_id,name,status,updated_time"
+cmd = "/v17.0/{act_id}/adrules_library -d limit=300 -d fields=id,account_id,name,status,updated_time"
 
 [ad_video]
-cmd = "/v16.0/{act_id}/advideos -d limit=300 -d fields=id,title,permalink_url,file_size,file_url,created_time,updated_time"
+cmd = "/v17.0/{act_id}/advideos -d limit=300 -d fields=id,title,permalink_url,file_size,file_url,created_time,updated_time"
 EOF


### PR DESCRIPTION
# 実装内容
* Facebook Graph API v17.0 対応

# 確認手順
## 準備
- facebook.cr.git クローン
- facebook コマンドコンパイル
- facebook-pb コマンドコンパイル
- コンフィグ生成(access_tokenを追記)

## 実行コマンド
以下実行コマンドです。
```
$ ./bin/facebook batch recv 20230912
```

### 確認
```
$ ../../bin/facebook-pb pb list HttpCall|cut -c 1-43|head
```

## 確認ポイント
- [x] 正常終了
- [x] v17 に切り替えてAPI実行

# その他
特にありません。